### PR TITLE
Refactor the title parser to use the title DOM element, (#4)

### DIFF
--- a/js/utils/parsers/title.js
+++ b/js/utils/parsers/title.js
@@ -1,14 +1,9 @@
-import awaitElement from '../awaitElement';
-
-const TITLE_SELECTOR = '#container > h1';
-
-const TITLE_SPLIT_REGEX = /(.*)(\||\/\/\/|-|:)(.*)/
+const TITLE_SPLIT_REGEX = /(.*)(\||\/\/\/|-|:)(.*)(\s-\sYouTube)$/
 const BRACKET_REGEX = /(\(|\[|\{).*(\}|\]|\))/
 const FEAT_REGEX = /(\sfeat|\sft.).*/i
 const OFFICIAL_REGEX = /(\sofficial video).*/i
 
-const getTitle = async () =>
-  await awaitElement(TITLE_SELECTOR);
+const getTitle = async () => document.title;
 
 /**
  *
@@ -34,6 +29,6 @@ const sandTitle = title => {
  * @returns {metadata} Metadata for the lyrics provider
  */
 export const getMetadata = () => {
-  return getTitle().then(title => sandTitle(title.innerText));
+  return getTitle().then(sandTitle);
 }
 

--- a/js/utils/parsers/title.js
+++ b/js/utils/parsers/title.js
@@ -3,7 +3,7 @@ const BRACKET_REGEX = /(\(|\[|\{).*(\}|\]|\))/
 const FEAT_REGEX = /(\sfeat|\sft.).*/i
 const OFFICIAL_REGEX = /(\sofficial video).*/i
 
-const getTitle = async () => document.title;
+const getTitle = () => document.title;
 
 /**
  *
@@ -29,6 +29,6 @@ const sandTitle = title => {
  * @returns {metadata} Metadata for the lyrics provider
  */
 export const getMetadata = () => {
-  return getTitle().then(sandTitle);
+  return sandTitle(getTitle());
 }
 


### PR DESCRIPTION
The title of the Youtube page is always the same as the youtube music
video title so instead of using query selector we can use the document
title. Fixes #4 